### PR TITLE
bugfix:SegmentAssert.refEquals sometimes not right

### DIFF
--- a/src/main/java/org/skywalking/apm/test/agent/tool/validator/assertor/SegmentAssert.java
+++ b/src/main/java/org/skywalking/apm/test/agent/tool/validator/assertor/SegmentAssert.java
@@ -83,11 +83,11 @@ public class SegmentAssert {
     }
 
     private static void refEquals(List<SegmentRef> excepted, List<SegmentRef> actual) {
-        if (excepted == null) {
+        if (excepted == null && actual == null) {
             return;
         }
-
-        if (actual == null || excepted.size() != actual.size()) {
+        boolean eitherIsNull = (excepted == null && actual != null) || (excepted != null && actual == null);
+        if (eitherIsNull || excepted.size() != actual.size()) {
             throw new AssertFailedException("ref is not equals");
         }
     }


### PR DESCRIPTION
bugfix:SegmentAssert.refEquals sometimes not right
old method is : 
```
    private static void refEquals(List<SegmentRef> excepted, List<SegmentRef> actual) {
        if (excepted == null) {
            return;
        }

        if (actual == null || excepted.size() != actual.size()) {
            throw new AssertFailedException("ref is not equals");
        }
    }
```
expect ref is : 
```
  - segmentId: not null
    spans:
    - operationName: /case/cross-thread
      operationId: 0
      parentSpanId: -1
      spanId: 0
      spanLayer: Http
      startTime: nq 0
      endTime: nq 0
      componentId: not null
      componentName: ''
      isError: false
      spanType: Entry
      peer: ''
      peerId: 0
      tags:
      - {key: url, value: not null }
      - {key: http.method, value: GET }
```
actual
```
  - segmentId: 1.53.15233554930920000
    spans:
    - operationName: /case/echo
      operationId: '0'
      parentSpanId: '-1'
      spanId: '0'
      spanLayer: Http
      tags:
      - {key: url, value: 'http://localhost:8080/jdk-cross-thread-scenario/case/echo'}
      - {key: http.method, value: GET}
      refs:
      - {parentServiceId: 0, parentServiceName: Thread/org.apache.skywalking.apm.toolkit.trace.CallableWrapper/call,
        networkAddressId: 0, entryServiceId: 0, refType: CrossProcess, parentSpanId: 1,
        parentTraceSegmentId: 1.52.15233554928410000, parentApplicationInstanceId: 1,
        networkAddress: 'localhost:8080', entryServiceName: /case/cross-thread, entryApplicationInstanceId: 1}
      startTime: '1523355493092'
      endTime: '1523355493133'
      componentId: '14'
      componentName: ''
      isError: false
      spanType: Entry
      peer: ''
      peerId: '0'
```